### PR TITLE
✨ Feat/settings

### DIFF
--- a/django_announcement/constants/default_settings.py
+++ b/django_announcement/constants/default_settings.py
@@ -1,0 +1,72 @@
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass(frozen=True)
+class DefaultCommandSettings:
+    generate_audiences_exclude_apps: List[str] = field(default_factory=lambda: [])
+    generate_audiences_exclude_models: List[str] = field(default_factory=lambda: [])
+
+
+@dataclass(frozen=True)
+class DefaultSerializerSettings:
+    include_serializer_full_details: bool = False
+    exclude_serializer_empty_fields: bool = False
+
+
+# pylint: disable=too-many-instance-attributes
+@dataclass(frozen=True)
+class DefaultAdminSettings:
+    admin_site_class: Optional[str] = None
+    admin_has_add_permission: bool = True
+    admin_has_change_permission: bool = True
+    admin_has_delete_permission: bool = True
+    admin_has_module_permission: bool = True
+    admin_inline_has_add_permission: bool = True
+    admin_inline_has_change_permission: bool = False
+    admin_inline_has_delete_permission: bool = True
+    admin_inline_has_module_permission: bool = True
+
+
+@dataclass(frozen=True)
+class DefaultThrottleSettings:
+    authenticated_user_throttle_rate: str = "30/minute"
+    staff_user_throttle_rate: str = "100/minute"
+    throttle_class: str = (
+        "django_announcement.api.throttlings.RoleBasedUserRateThrottle"
+    )
+
+
+@dataclass(frozen=True)
+class DefaultPaginationAndFilteringSettings:
+    pagination_class: str = (
+        "django_announcement.api.paginations.DefaultLimitOffSetPagination"
+    )
+    filterset_class: Optional[str] = None
+    ordering_fields: List[str] = field(
+        default_factory=lambda: [
+            "id",
+            "published_at",
+            "expires_at",
+            "created_at",
+            "updated_at",
+        ]
+    )
+    search_fields: List[str] = field(
+        default_factory=lambda: ["title", "content", "category__name"]
+    )
+
+
+# pylint: disable=too-many-instance-attributes
+@dataclass(frozen=True)
+class DefaultAPISettings:
+    allow_list: bool = True
+    allow_retrieve: bool = True
+    extra_permission_class: Optional[str] = None
+    parser_classes: List[str] = field(
+        default_factory=lambda: [
+            "rest_framework.parsers.JSONParser",
+            "rest_framework.parsers.MultiPartParser",
+            "rest_framework.parsers.FormParser",
+        ]
+    )

--- a/django_announcement/settings/conf.py
+++ b/django_announcement/settings/conf.py
@@ -1,0 +1,216 @@
+from typing import Any, List, Optional, Type, Union
+
+from django.conf import settings
+from django.utils.module_loading import import_string
+
+from django_announcement.constants.default_settings import (
+    DefaultAdminSettings,
+    DefaultAPISettings,
+    DefaultPaginationAndFilteringSettings,
+    DefaultSerializerSettings,
+    DefaultThrottleSettings,
+    DefaultCommandSettings,
+)
+
+
+# pylint: disable=too-many-instance-attributes
+class AnnouncementConfig:
+    """A configuration handler for the Django Announcement API, allowing
+    settings to be dynamically loaded from Django settings with defaults
+    provided through `DefaultSettings`.
+
+    Attributes:
+        include_serializer_full_details (bool): Whether full details are included in the serializer.
+        exclude_serializer_empty_fields (bool): Whether empty fields should be excluded in the serializer.
+        api_allow_list (bool): Whether the API allows listing announcements.
+        api_allow_retrieve (bool): Whether the API allows retrieving single announcements.
+        authenticated_user_throttle_rate (str): Throttle rate for authenticated users.
+        staff_user_throttle_rate (str): Throttle rate for staff users.
+        api_throttle_class (Optional[Type[Any]]): The class used for request throttling.
+        api_pagination_class (Optional[Type[Any]]): The class used for pagination.
+        api_extra_permission_class (Optional[Type[Any]]): An additional permission class for the API.
+        api_parser_classes (Optional[List[Type[Any]]]): A list of parser classes used for the API.
+        api_filterset_class (Optional[Type[Any]]): The class used for filtering announcements.
+        api_ordering_fields (List[str]): Fields that can be used for ordering announcements in API queries.
+        api_search_fields (List[str]): Fields that can be searched in API queries.
+        admin_has_add_permission (bool): Whether the admin has permission to add announcements.
+        admin_has_change_permission (bool): Whether the admin has permission to change announcements.
+        admin_has_delete_permission (bool): Whether the admin has permission to delete announcements.
+        admin_has_module_permission (bool): Whether the admin has module-level permissions.
+        admin_inline_has_add_permission (bool): Whether the inline admin has permission to add announcements.
+        admin_inline_has_change_permission (bool): Whether the inline admin has permission to change announcements.
+        admin_inline_has_delete_permission (bool): Whether the inline admin has permission to delete announcements.
+        admin_inline_has_module_permission (bool): Whether the inline admin has module-level permissions.
+        admin_site_class (Optional[Type[Any]]): The class used for the admin site.
+        generate_audiences_exclude_apps (List[str]): A list of apps excluded from audience generation.
+        generate_audiences_exclude_models (List[str]): A list of models excluded from audience generation.
+    """
+
+    prefix = "DJANGO_ANNOUNCEMENT_"
+
+    default_api_settings: DefaultAPISettings = DefaultAPISettings()
+    default_serializer_settings: DefaultSerializerSettings = DefaultSerializerSettings()
+    default_admin_settings: DefaultAdminSettings = DefaultAdminSettings()
+    default_pagination_and_filter_settings: DefaultPaginationAndFilteringSettings = (
+        DefaultPaginationAndFilteringSettings()
+    )
+    default_throttle_settings: DefaultThrottleSettings = DefaultThrottleSettings()
+    default_command_settings: DefaultCommandSettings = DefaultCommandSettings()
+
+    def __init__(self) -> None:
+        """Initialize the AnnouncementConfig, loading values from Django
+        settings or falling back to the default settings."""
+
+        self.admin_has_add_permission: bool = self.get_setting(
+            f"{self.prefix}ADMIN_HAS_ADD_PERMISSION",
+            self.default_admin_settings.admin_has_add_permission,
+        )
+        self.admin_has_change_permission: bool = self.get_setting(
+            f"{self.prefix}ADMIN_HAS_CHANGE_PERMISSION",
+            self.default_admin_settings.admin_has_change_permission,
+        )
+        self.admin_has_delete_permission: bool = self.get_setting(
+            f"{self.prefix}ADMIN_HAS_DELETE_PERMISSION",
+            self.default_admin_settings.admin_has_delete_permission,
+        )
+        self.admin_has_module_permission: bool = self.get_setting(
+            f"{self.prefix}ADMIN_HAS_MODULE_PERMISSION",
+            self.default_admin_settings.admin_has_module_permission,
+        )
+        self.admin_inline_has_add_permission: bool = self.get_setting(
+            f"{self.prefix}ADMIN_INLINE_HAS_ADD_PERMISSION",
+            self.default_admin_settings.admin_inline_has_add_permission,
+        )
+        self.admin_inline_has_change_permission: bool = self.get_setting(
+            f"{self.prefix}ADMIN_INLINE_HAS_CHANGE_PERMISSION",
+            self.default_admin_settings.admin_inline_has_change_permission,
+        )
+        self.admin_inline_has_delete_permission: bool = self.get_setting(
+            f"{self.prefix}ADMIN_INLINE_HAS_DELETE_PERMISSION",
+            self.default_admin_settings.admin_inline_has_delete_permission,
+        )
+        self.admin_inline_has_module_permission: bool = self.get_setting(
+            f"{self.prefix}ADMIN_INLINE_HAS_MODULE_PERMISSION",
+            self.default_admin_settings.admin_inline_has_module_permission,
+        )
+
+        self.include_serializer_full_details: bool = self.get_setting(
+            f"{self.prefix}SERIALIZER_INCLUDE_FULL_DETAILS",
+            self.default_serializer_settings.include_serializer_full_details,
+        )
+        self.exclude_serializer_empty_fields: bool = self.get_setting(
+            f"{self.prefix}SERIALIZER_EXCLUDE_EMPTY_FIELDS",
+            self.default_serializer_settings.exclude_serializer_empty_fields,
+        )
+
+        self.api_allow_list: bool = self.get_setting(
+            f"{self.prefix}API_ALLOW_LIST", self.default_api_settings.allow_list
+        )
+        self.api_allow_retrieve: bool = self.get_setting(
+            f"{self.prefix}API_ALLOW_RETRIEVE",
+            self.default_api_settings.allow_retrieve,
+        )
+        self.generate_audiences_exclude_apps: List[str] = self.get_setting(
+            f"{self.prefix}GENERATE_AUDIENCES_EXCLUDE_APPS",
+            self.default_command_settings.generate_audiences_exclude_apps,
+        )
+        self.generate_audiences_exclude_models: List[str] = self.get_setting(
+            f"{self.prefix}GENERATE_AUDIENCES_EXCLUDE_MODELS",
+            self.default_command_settings.generate_audiences_exclude_models,
+        )
+        self.authenticated_user_throttle_rate: str = self.get_setting(
+            f"{self.prefix}AUTHENTICATED_USER_THROTTLE_RATE",
+            self.default_throttle_settings.authenticated_user_throttle_rate,
+        )
+        self.staff_user_throttle_rate: str = self.get_setting(
+            f"{self.prefix}STAFF_USER_THROTTLE_RATE",
+            self.default_throttle_settings.staff_user_throttle_rate,
+        )
+        self.api_throttle_class: Optional[Type[Any]] = self.get_optional_classes(
+            f"{self.prefix}API_THROTTLE_CLASS",
+            self.default_throttle_settings.throttle_class,
+        )
+        self.api_pagination_class: Optional[Type[Any]] = self.get_optional_classes(
+            f"{self.prefix}API_PAGINATION_CLASS",
+            self.default_pagination_and_filter_settings.pagination_class,
+        )
+        self.api_extra_permission_class: Optional[Type[Any]] = (
+            self.get_optional_classes(
+                f"{self.prefix}API_EXTRA_PERMISSION_CLASS",
+                self.default_api_settings.extra_permission_class,
+            )
+        )
+        self.api_parser_classes: Optional[List[Type[Any]]] = self.get_optional_classes(
+            f"{self.prefix}API_PARSER_CLASSES",
+            self.default_api_settings.parser_classes,
+        )
+        self.api_filterset_class: Optional[Type[Any]] = self.get_optional_classes(
+            f"{self.prefix}API_FILTERSET_CLASS",
+            self.default_pagination_and_filter_settings.filterset_class,
+        )
+        self.api_ordering_fields: List[str] = self.get_setting(
+            f"{self.prefix}API_ORDERING_FIELDS",
+            self.default_pagination_and_filter_settings.ordering_fields,
+        )
+        self.api_search_fields: List[str] = self.get_setting(
+            f"{self.prefix}API_SEARCH_FIELDS",
+            self.default_pagination_and_filter_settings.search_fields,
+        )
+        self.admin_site_class: Optional[Type[Any]] = self.get_optional_classes(
+            f"{self.prefix}ADMIN_SITE_CLASS",
+            self.default_admin_settings.admin_site_class,
+        )
+
+    def get_setting(self, setting_name: str, default_value: Any) -> Any:
+        """Retrieve a setting from Django settings with a default fallback.
+
+        Args:
+            setting_name (str): The name of the setting to retrieve.
+            default_value (Any): The default value to return if the setting is not found.
+
+        Returns:
+            Any: The value of the setting or the default value if not found.
+
+        """
+        return getattr(settings, setting_name, default_value)
+
+    def get_optional_classes(
+        self,
+        setting_name: str,
+        default_path: Optional[Union[str, List[str]]],
+    ) -> Optional[Union[Type[Any], List[Type[Any]]]]:
+        """Dynamically load a class based on a setting, or return None if the
+        setting is None or invalid.
+
+        Args:
+            setting_name (str): The name of the setting for the class path.
+            default_path (Optional[Union[str, List[str]]): The default import path for the class.
+
+        Returns:
+            Optional[Union[Type[Any], List[Type[Any]]]]: The imported class or None
+             if import fails or the path is invalid.
+
+        """
+        class_path: Optional[Union[str, List[str]]] = self.get_setting(
+            setting_name, default_path
+        )
+
+        if class_path and isinstance(class_path, str):
+            try:
+                return import_string(class_path)
+            except ImportError:
+                return None
+        elif class_path and isinstance(class_path, list):
+            try:
+                return [
+                    import_string(cls_path)
+                    for cls_path in class_path
+                    if isinstance(cls_path, str)
+                ]
+            except ImportError:
+                return []
+
+        return None
+
+
+config: AnnouncementConfig = AnnouncementConfig()


### PR DESCRIPTION
- Introduced DefaultCommandSettings to manage audience generation exclusions for apps and models.
- Created DefaultSerializerSettings to define serialization options, including full details and exclusion of empty fields.
- Added DefaultAdminSettings for fine-tuning admin permissions and site class configuration.
- Implemented DefaultThrottleSettings to establish default throttle rates for authenticated and staff users, along with a specified throttle class.
- Developed DefaultPaginationAndFilteringSettings to set default pagination, filtering, and ordering fields for API responses.
- Established DefaultAPISettings to configure permissions, parser classes, and additional options for API access.

These classes provide a structured way to manage default configurations across various components of the dj-announcement-api, enhancing maintainability and customization capabilities.

- Implemented the AnnouncementConfig class to manage settings for the Django Announcement API.
- The class dynamically loads configuration values from Django settings, falling back to predefined defaults defined in DefaultSettings.
- Introduced attributes to manage various settings, including:
  - Admin permissions (add, change, delete, module-level)
  - Serializer options (full details inclusion, exclusion of empty fields)
  - API behavior (allow list/retrieve, throttle rates, pagination, filtering)
  - Audience generation exclusions (apps and models)
- Added methods for retrieving settings (get_setting) and dynamically importing classes (get_optional_classes).
- Enhanced maintainability and customization of the Announcement API through structured and accessible configuration management.

This implementation provides a comprehensive approach to managing configuration settings, improving flexibility and clarity within the dj-announcement-api.

Closes https://github.com/Lazarus-org/dj-announcement-api/issues/13