### PR TITLE
✨ Feat/admin dynamic perm

### DIFF
--- a/django_announcement/constants/default_settings.py
+++ b/django_announcement/constants/default_settings.py
@@ -25,7 +25,6 @@ class DefaultAdminSettings:
     admin_inline_has_add_permission: bool = True
     admin_inline_has_change_permission: bool = False
     admin_inline_has_delete_permission: bool = True
-    admin_inline_has_module_permission: bool = True
 
 
 @dataclass(frozen=True)

--- a/django_announcement/mixins/admin/base.py
+++ b/django_announcement/mixins/admin/base.py
@@ -2,9 +2,12 @@ from django.contrib.admin import ModelAdmin
 from django.utils.translation import gettext_lazy as _
 
 from django_announcement.mixins.admin.form_fields import ForeignKeyRawIdWidgetMixin
+from django_announcement.mixins.admin.permission import AdminPermissionControlMixin
 
 
-class BaseModelAdmin(ForeignKeyRawIdWidgetMixin, ModelAdmin):
+class BaseModelAdmin(
+    AdminPermissionControlMixin, ForeignKeyRawIdWidgetMixin, ModelAdmin
+):
     """Base class for all ModelAdmin classes in the Django admin interface.
 
     This class provides common functionalities and configurations that can
@@ -25,6 +28,7 @@ class BaseModelAdmin(ForeignKeyRawIdWidgetMixin, ModelAdmin):
         Subclass `BaseModelAdmin` to create custom admin interfaces for your models,
         inheriting the common configurations and functionalities provided by this base class.
     """
+
     list_display = ["id"]
     list_per_page = 10
     list_filter = ["created_at", "updated_at"]

--- a/django_announcement/mixins/admin/inlines.py
+++ b/django_announcement/mixins/admin/inlines.py
@@ -3,9 +3,12 @@ from django.db.models import QuerySet
 from django.http import HttpRequest
 
 from django_announcement.mixins.admin.form_fields import ForeignKeyRawIdWidgetMixin
+from django_announcement.mixins.admin.permission import InlinePermissionControlMixin
 
 
-class BaseTabularInline(ForeignKeyRawIdWidgetMixin, TabularInline):
+class BaseTabularInline(
+    InlinePermissionControlMixin, ForeignKeyRawIdWidgetMixin, TabularInline
+):
     """Base tabular inline admin interface with common functionality for all inlines.
 
     This class serves as the foundation for all inlines. Any tabular inline can inherit from this

--- a/django_announcement/mixins/admin/permission.py
+++ b/django_announcement/mixins/admin/permission.py
@@ -1,0 +1,48 @@
+from typing import Optional
+
+from django.contrib.admin import ModelAdmin
+from django.http import HttpRequest
+
+from django_announcement.settings.conf import config
+
+
+class BasePermissionControlMixin:
+    """A base mixin to control the add, change, delete permissions in the Django admin."""
+
+    permission_prefix = ""
+
+    def has_add_permission(
+        self, request: HttpRequest, obj: Optional[ModelAdmin] = None
+    ) -> bool:
+        """Determines if the user has permission to add a new instance of the model."""
+        return getattr(config, f"{self.permission_prefix}has_add_permission")
+
+    def has_change_permission(
+        self, request: HttpRequest, obj: Optional[ModelAdmin] = None
+    ) -> bool:
+        """Determines if the user has permission to change an existing instance of the model."""
+        return getattr(config, f"{self.permission_prefix}has_change_permission")
+
+    def has_delete_permission(
+        self, request: HttpRequest, obj: Optional[ModelAdmin] = None
+    ) -> bool:
+        """Determines if the user has permission to delete an existing instance of the model."""
+        return getattr(config, f"{self.permission_prefix}has_delete_permission")
+
+
+class AdminPermissionControlMixin(BasePermissionControlMixin):
+    """A mixin that controls the ability to add, change, or delete objects and module permission in
+    the Django admin."""
+
+    permission_prefix = "admin_"
+
+    def has_module_permission(self, request: HttpRequest) -> bool:
+        """Determines if the user has any permission in the given app label."""
+        return getattr(config, f"{self.permission_prefix}has_module_permission")
+
+
+class InlinePermissionControlMixin(BasePermissionControlMixin):
+    """A mixin that controls the ability to add, change, or delete inline objects in
+    the Django admin."""
+
+    permission_prefix = "admin_inline_"

--- a/django_announcement/settings/conf.py
+++ b/django_announcement/settings/conf.py
@@ -40,7 +40,6 @@ class AnnouncementConfig:
         admin_inline_has_add_permission (bool): Whether the inline admin has permission to add announcements.
         admin_inline_has_change_permission (bool): Whether the inline admin has permission to change announcements.
         admin_inline_has_delete_permission (bool): Whether the inline admin has permission to delete announcements.
-        admin_inline_has_module_permission (bool): Whether the inline admin has module-level permissions.
         admin_site_class (Optional[Type[Any]]): The class used for the admin site.
         generate_audiences_exclude_apps (List[str]): A list of apps excluded from audience generation.
         generate_audiences_exclude_models (List[str]): A list of models excluded from audience generation.
@@ -88,10 +87,6 @@ class AnnouncementConfig:
         self.admin_inline_has_delete_permission: bool = self.get_setting(
             f"{self.prefix}ADMIN_INLINE_HAS_DELETE_PERMISSION",
             self.default_admin_settings.admin_inline_has_delete_permission,
-        )
-        self.admin_inline_has_module_permission: bool = self.get_setting(
-            f"{self.prefix}ADMIN_INLINE_HAS_MODULE_PERMISSION",
-            self.default_admin_settings.admin_inline_has_module_permission,
         )
 
         self.include_serializer_full_details: bool = self.get_setting(


### PR DESCRIPTION
- Implemented BasePermissionControlMixin to handle add, change, and delete permissions dynamically in the Django admin.
- Introduced AdminPermissionControlMixin, extending the base mixin, to control admin-level permissions and provide support for has_module_permission.
- Added InlinePermissionControlMixin to manage permissions for inline classes separately, allowing fine-grained control over inline object actions.
- Permissions are dynamically retrieved from the configuration using config settings with customizable prefixes for both admin and inline permissions.

