### PR TITLE
:sparkles: feat(filters): Add AnnouncementFilter for Filtering Announcements

### DIFF
--- a/django_announcement/api/filters/announcement_filter.py
+++ b/django_announcement/api/filters/announcement_filter.py
@@ -1,0 +1,51 @@
+from django_filters import BooleanFilter
+from django_filters.rest_framework import FilterSet, DateTimeFromToRangeFilter
+from django_announcement.models.announcement import Announcement
+
+
+class AnnouncementFilter(FilterSet):
+    """Filter set for filtering announcements based on various criteria."""
+
+    created_at = DateTimeFromToRangeFilter(
+        field_name="created_at",
+        lookup_expr="range",
+        help_text="Filter announcements by created_at within a specific range.",
+    )
+
+    published_at = DateTimeFromToRangeFilter(
+        field_name="published_at",
+        lookup_expr="range",
+        help_text="Filter announcements by published_at within a specific range.",
+    )
+
+    expires_at = DateTimeFromToRangeFilter(
+        field_name="expires_at",
+        lookup_expr="range",
+        help_text="Filter announcements by expires_at within a specific range.",
+    )
+
+    not_expired = BooleanFilter(
+        field_name="expires_at",
+        method="filter_not_expired",
+        label="active (not expired)",
+        help_text="Filter announcements that have not yet expired.",
+    )
+
+    class Meta:
+        model = Announcement
+        fields = {
+            "audience__id": ["exact"],
+            "category__id": ["exact"],
+            "title": [
+                "icontains",
+                "exact",
+            ],
+            "content": ["icontains"],
+        }
+
+    def filter_not_expired(self, queryset, name, value):
+        """Filter announcements that are not expired (i.e., expires_at is None or in the future)."""
+        if value:
+            return queryset.active()
+
+        return queryset


### PR DESCRIPTION
This commit introduces the AnnouncementFilter class, which provides a set of filtering capabilities for announcements based on various criteria. The filter set allows users to filter announcements by:

- **Creation Date**: Filter announcements created within a specific date range using created_at.
- **Publication Date**: Filter announcements published within a specific date range using published_at.
- **Expiration Date**: Filter announcements that are set to expire within a specific date range using expires_at.
- **Active Status**: A boolean filter (not_expired) that allows users to filter announcements that have not yet expired.

The AnnouncementFilter leverages Django Filter's FilterSet and includes:
- DateTimeFromToRangeFilter for filtering date fields.
- A custom filter method (filter_not_expired) to check if announcements are still active.

The Meta class defines the model as Announcement and specifies additional fields for filtering, including audience and category IDs, as well as title and content matching.

This addition enhances the API's ability to filter announcements effectively, improving usability for clients.

Closes #24